### PR TITLE
Add check to parser.js for /data folder, exclude .babelrc, package.json repo URLs linked to OSLabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/BeckettH/CodeMapper.git"
+    "url": "git+https://github.com/oslabs-beta/CodeMapper.git"
   },
   "author": "RabbitHole",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/BeckettH/CodeMapper/issues"
+    "url": "https://github.com/oslabs-beta/CodeMapper/issues"
   },
-  "homepage": "https://github.com/BeckettH/CodeMapper#readme",
+  "homepage": "https://github.com/oslabs-beta/CodeMapper#readme",
   "dependencies": {
     "@babel/core": "^7.11.0",
     "@babel/generator": "^7.11.0",

--- a/src/getUserInput.js
+++ b/src/getUserInput.js
@@ -13,6 +13,7 @@ const excludeArr = [
   'node_modules',
   'LICENSE',
   '.git',
+  '.babelrc',
   '.DS_Store',
   '.vscode',
   'package.json',


### PR DESCRIPTION
**Issues Addressed**:  Changes were made to `parser.js` to use the Node path module to fix a problem for fs.writeFileSync method when writing to the `data.json` AST file to `/data` folder.  Initially the file wasn't being written to the folder as expected.  Update `package.json` URLs.  Exclude `.babelrc` from being mapped.

**Changes Made**:  
1. Used the native Node `path` module with the `resolve` method to have a absolute path to that folder. Changed `fs.writeFileSync('../data/data.json', JSON.stringify(ast, null, 2)` to `fs.writeFileSync(PATH.resolve(__dirname, '../data/data.json'), JSON.stringify(ast, null, 2));`
2. Changed `package.json` URLs to link to the CodeMapper OSLabs repository.
3.  Add `.babelrc` to `getUserInput.js excludeArr` array variable.